### PR TITLE
Prevent 400 (bad request) on API calls by adding user data validation

### DIFF
--- a/template.js
+++ b/template.js
@@ -69,35 +69,56 @@ if (isLoggingEnabled) {
   );
 }
 
-sendHttpRequest(
-  postUrl,
-  (statusCode, headers, body) => {
-    if (isLoggingEnabled) {
-      logToConsole(
-        JSON.stringify({
-          Name: 'LinkedIn',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: postBody.eventId,
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body
-        })
-      );
-    }
+// perform validation check on presence of 1/4 of the required IDs. If at least 1 ID is present, make the API call. If no IDs are present, log the warning and no call is made
+if (validateUserData()){
+  sendConversionToLinkedIn();
+} else {
+  logToConsole('No conversion event was sent to CAPI. You must set 1 out of the 4 acceptable IDs (SHA256_EMAIL, LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID, ACXIOM_ID, ORACLE_MOAT_ID) to resolve this issue or make certain to send both firstName and lastName.');
 
-    if (statusCode >= 200 && statusCode < 300) {
-      data.gtmOnSuccess();
-    } else {
-      data.gtmOnFailure();
-    }
-  },
-  {
-    headers: postHeaders,
-    method: 'POST'
-  },
-  JSON.stringify(postBody)
-);
+  data.gtmOnFailure();
+}
+
+function validateUserData() {
+  if (postBody.user.userIds.length > 0) {
+    return true;
+  }
+
+  return postBody.user.userInfo.firstName != "" &&
+    postBody.user.userInfo.lastName != "";
+}
+
+
+function sendConversionToLinkedIn() {
+  sendHttpRequest(
+    postUrl,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'LinkedIn',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: postBody.eventId,
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
+
+      if (statusCode >= 200 && statusCode < 300) {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    {
+      headers: postHeaders,
+      method: 'POST'
+    },
+    JSON.stringify(postBody)
+  );
+}
 
 function getRequestUrl() {
   return 'https://api.linkedin.com/rest/conversionEvents';

--- a/template.js
+++ b/template.js
@@ -73,7 +73,16 @@ if (isLoggingEnabled) {
 if (validateUserData()){
   sendConversionToLinkedIn();
 } else {
-  logToConsole('No conversion event was sent to CAPI. You must set 1 out of the 4 acceptable IDs (SHA256_EMAIL, LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID, ACXIOM_ID, ORACLE_MOAT_ID) to resolve this issue or make certain to send both firstName and lastName.');
+  if (isLoggingEnabled) {
+    logToConsole({
+      Name: 'LinkedIn',
+      Type: 'Message',
+      TraceId: traceId,
+      EventName: postBody.eventId,
+      Message: 'No conversion event was sent to LinkedIn CAPI.',
+      Reason: 'You must set 1 out of the 4 acceptable IDs (SHA256_EMAIL, LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID, ACXIOM_ID, ORACLE_MOAT_ID) to resolve this issue or make certain to send both firstName and lastName.',
+    });
+  }
 
   data.gtmOnFailure();
 }
@@ -83,8 +92,7 @@ function validateUserData() {
     return true;
   }
 
-  return postBody.user.userInfo.firstName != "" &&
-    postBody.user.userInfo.lastName != "";
+  return postBody.user.userInfo.firstName && postBody.user.userInfo.lastName;
 }
 
 

--- a/template.tpl
+++ b/template.tpl
@@ -376,7 +376,16 @@ if (isLoggingEnabled) {
 if (validateUserData()){
   sendConversionToLinkedIn();
 } else {
-  logToConsole('No conversion event was sent to CAPI. You must set 1 out of the 4 acceptable IDs (SHA256_EMAIL, LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID, ACXIOM_ID, ORACLE_MOAT_ID) to resolve this issue or make certain to send both firstName and lastName.');
+  if (isLoggingEnabled) {
+    logToConsole({
+      Name: 'LinkedIn',
+      Type: 'Message',
+      TraceId: traceId,
+      EventName: postBody.eventId,
+      Message: 'No conversion event was sent to LinkedIn CAPI.',
+      Reason: 'You must set 1 out of the 4 acceptable IDs (SHA256_EMAIL, LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID, ACXIOM_ID, ORACLE_MOAT_ID) to resolve this issue or make certain to send both firstName and lastName.',
+    });
+  }
 
   data.gtmOnFailure();
 }
@@ -386,8 +395,7 @@ function validateUserData() {
     return true;
   }
 
-  return postBody.user.userInfo.firstName != "" &&
-    postBody.user.userInfo.lastName != "";
+  return postBody.user.userInfo.firstName && postBody.user.userInfo.lastName;
 }
 
 

--- a/template.tpl
+++ b/template.tpl
@@ -372,35 +372,56 @@ if (isLoggingEnabled) {
   );
 }
 
-sendHttpRequest(
-  postUrl,
-  (statusCode, headers, body) => {
-    if (isLoggingEnabled) {
-      logToConsole(
-        JSON.stringify({
-          Name: 'LinkedIn',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: postBody.eventId,
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body
-        })
-      );
-    }
+// perform validation check on presence of 1/4 of the required IDs. If at least 1 ID is present, make the API call. If no IDs are present, log the warning and no call is made
+if (validateUserData()){
+  sendConversionToLinkedIn();
+} else {
+  logToConsole('No conversion event was sent to CAPI. You must set 1 out of the 4 acceptable IDs (SHA256_EMAIL, LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID, ACXIOM_ID, ORACLE_MOAT_ID) to resolve this issue or make certain to send both firstName and lastName.');
 
-    if (statusCode >= 200 && statusCode < 300) {
-      data.gtmOnSuccess();
-    } else {
-      data.gtmOnFailure();
-    }
-  },
-  {
-    headers: postHeaders,
-    method: 'POST'
-  },
-  JSON.stringify(postBody)
-);
+  data.gtmOnFailure();
+}
+
+function validateUserData() {
+  if (postBody.user.userIds.length > 0) {
+    return true;
+  }
+
+  return postBody.user.userInfo.firstName != "" &&
+    postBody.user.userInfo.lastName != "";
+}
+
+
+function sendConversionToLinkedIn() {
+  sendHttpRequest(
+    postUrl,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'LinkedIn',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: postBody.eventId,
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
+
+      if (statusCode >= 200 && statusCode < 300) {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    {
+      headers: postHeaders,
+      method: 'POST'
+    },
+    JSON.stringify(postBody)
+  );
+}
 
 function getRequestUrl() {
   return 'https://api.linkedin.com/rest/conversionEvents';


### PR DESCRIPTION
LinkedIn CAPI fails when there's no ID set and no user information (first and last name).

This PR ads a simple validation to prevent the API call in case there's no IDs, firstname, and lastname.

Example output:
![image](https://github.com/stape-io/linkedin-tag/assets/6016632/039cd019-cd74-4234-9c0f-99b8e39ae38a)

The tag will also fail when the validation fails intentionally by calling `data.gtmOnFailure()`.

This PR is inspired by the official linkedin tag.
https://github.com/linkedin-developers/linkedin-capi-tag-template/blob/d297e46cc267a7bed3f44b6b974f9d7efd311e8b/template.tpl#L156-L160